### PR TITLE
Specify path to favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>Badger Map</title>
     <meta charset="utf-8" />
+    <link rel="icon" href="./favicon.ico" type="image/x-icon">
     <style type="text/css">
       html,
       body {


### PR DESCRIPTION
GitHub pages are served from a non-root path, so we can't rely on browsers loading the favicon from /favicon.ico.

Fixes favicon, which was added in #15.

I tested that by opening current version in from GitHub pages in the browser. Then I opened the dev tools and added the tag in the `<head>`. Firefox immediately loaded the favicon.