### PR TITLE
Improve scaling on mobile devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>Badger Map</title>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
     <link rel="icon" href="./favicon.ico" type="image/x-icon" />
     <style type="text/css">
       html,
@@ -10,7 +11,6 @@
         height: 100%;
         margin: 0;
         padding: 0;
-        font-size: 14px;
         font-family: Arial, Helvetica, sans-serif;
       }
 
@@ -19,13 +19,16 @@
       }
 
       .map-info-window {
-        font-size: 14px;
-        padding: 0 0.4em;
-        margin: -0.4em 0;
+        padding: 0.5em;
       }
 
       .map-info-window h1 {
-        font-size: 110%;
+        font-size: 1.3em;
+        margin: 0.3rem 0 1rem;
+      }
+
+      .map-info-window p {
+        margin: 1rem 0 0.3rem;
       }
 
       .map-info-window table th {
@@ -33,31 +36,30 @@
       }
 
       #authorize-dialog {
-        width: 30%;
+        width: 90%;
+        max-width: 30em;
         background-color: white;
+        box-sizing: border-box;
         border-radius: 15px;
         box-shadow: 0px 5px 10px 2px #888888;
-        position: absolute;
+        padding: 1.5em;
+        position: fixed;
         top: 30%;
-        left: 35%;
+        left: 50%;
+        transform: translateX(-50%);
         z-index: 10;
       }
 
       #authorize-dialog h1 {
-        padding: 0.2em 1em;
-        font-size: 26px;
+        margin: 0.2em 0;
+        font-size: 1.5em;
         font-weight: lighter;
       }
 
-      #authorize-dialog p {
-        padding: 0.2em 2em;
-        font-weight: normal;
-      }
-
       #authorize-button {
-        margin: 1em auto;
-        padding: 0.2em 0.5em;
-        font-size: 22px;
+        margin-top: 1em;
+        padding: 0.3em 0.8em;
+        font-size: 1.3em;
         color: white;
         font-weight: bold;
         background-color: #212121;
@@ -71,7 +73,8 @@
         box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px;
         left: 0;
         bottom: 0;
-        margin: 10px;
+        /* A bit more spacing on the right ensures the default zoom buttons are always accessible. */
+        margin: 10px 60px 10px 10px;
         padding: 10px 17px;
       }
 
@@ -92,7 +95,7 @@
 
     <div id="main"></div>
 
-    <div id="add-yourself-info">
+    <div id="add-yourself-info" style="display: none;">
       <h1>🗺 Not on the map yet?</h1>
       <p>
         Click on your home on the map to<br />see instructions for adding
@@ -117,6 +120,7 @@
 
       const authorizeDialog = document.getElementById("authorize-dialog");
       const authorizeButton = document.getElementById("authorize-button");
+      const addYourselfInfo = document.getElementById("add-yourself-info");
       let map, geocoder; // initialised by initMap()
 
       /**
@@ -307,6 +311,7 @@
             },
           });
         });
+        addYourselfInfo.style.display = "block";
       }
     </script>
 


### PR DESCRIPTION
- Scale to device width
- Better width for sign in popup depending on available width
- Use default browser font size
- Spacing relative to font size
- Only show the "add yourself" info when it's click handler has been setup

Should look like this on an iPhone:

<img src="https://user-images.githubusercontent.com/3579251/80799571-1bc24980-8b9f-11ea-8c84-0c73182db861.png" width="300">
